### PR TITLE
Create .pkgmeta

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -1,0 +1,9 @@
+# .pkgmeta
+package-as: WideQuestLogPlus
+enable-nolib-creation: no
+
+ignore:
+    - .github
+    - .pkgmeta
+    - LICENSE
+    - README.md


### PR DESCRIPTION
Setting up the Package Meta file... just some best practices, but easy since you have no dependencies to include.